### PR TITLE
Pulls/2.0/autopublish attached assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-cms:1.0.x-dev cwp/starter-theme:2.x-dev silverstripe/fulltextsearch:^3
+  - composer require --no-update silverstripe/recipe-cms:1.x-dev cwp/starter-theme:2.x-dev silverstripe/fulltextsearch:^3
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "cwp/cwp": "^2"
+        "cwp/cwp": "^2",
+        "silverstripe/framework": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -313,7 +313,8 @@ class CWPSiteConfigExtension extends DataExtension
         return $this;
     }
 
-    public function onAfterWrite() {
+    public function onAfterWrite()
+    {
         if (!$this->owner->hasExtension(Versioned::class)) {
             $this->owner->publishRecursive();
         }

--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -12,6 +12,7 @@ use SilverStripe\Assets\Image;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\SSViewer;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * Class CWPCleanupSiteConfigExtension
@@ -297,5 +298,11 @@ class CWPSiteConfigExtension extends DataExtension
         );
 
         return $this;
+    }
+
+    public function onAfterWrite() {
+        if (!$this->owner->hasExtension(Versioned::class)) {
+            $this->owner->publishRecursive();
+        }
     }
 }

--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -50,6 +50,19 @@ class CWPSiteConfigExtension extends DataExtension
         'AppleTouchIcon57' => File::class
     );
 
+    private static $owns = [
+        'Logo',
+        'LogoRetina',
+        'FooterLogo',
+        'FooterLogoRetina',
+        'FooterLogoSecondary',
+        'FavIcon',
+        'AppleTouchIcon144',
+        'AppleTouchIcon114',
+        'AppleTouchIcon72',
+        'AppleTouchIcon57'
+    ];
+
     /**
      * @param FieldList $fields
      */


### PR DESCRIPTION
Fixes #5 by increasing the minimum requirement of framework to resolve most of the issue automatically. CWP 2.0 will be based on 4.1 so this is safe - but as this module relies on functionality added after 4.0 this is made explicit via composer.json.