### PR TITLE
API Remove SiteConfig form fields for the CWP default theme, not used in starter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/silverstripe/cwp-agencyextensions.svg?branch=master)](https://travis-ci.org/silverstripe/cwp-agencyextensions)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/cwp-agencyextensions/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/cwp-agencyextensions/?branch=master)
+[![codecov](https://codecov.io/gh/silverstripe/cwp-agencyextensions/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/cwp-agencyextensions)
 
 This module provides some added configuration and underlying functionality that may be useful to allow clients/agencies to adjust website functionality theirselves, or to provide additional functionality that may not always be required for a CWP project. It provides the content management side of the functionality provided by the Watea theme (specifically the Carousel).
 
@@ -13,8 +14,6 @@ This module provides the following (may not be a definitive list):
 * Customise search results labels from SiteConfig
 * Upload custom header and footer logos from SiteConfig
 * Upload custom favicon and Apple touch logos from SiteConfig
-* Define an AddThis social media profile ID (used in CWP default theme, for example) from SiteConfig
-* Add frontend asset requirements for the CWP default theme
 * [FontAwesome](http://fontawesome.io) icon popup dialog to the TinyMCE content editor (Wātea theme only, by default)
 
 ## Installation

--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -2,16 +2,13 @@
 
 namespace CWP\AgencyExtensions\Extensions;
 
-use SilverStripe\Core\Config\Configurable;
-use SilverStripe\ORM\DataExtension;
-use SilverStripe\Core\Environment;
-use SilverStripe\Forms\FieldList;
 use SilverStripe\Assets\File;
-use SilverStripe\Forms\FileHandleField;
 use SilverStripe\Assets\Image;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\View\SSViewer;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FileHandleField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataExtension;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -19,16 +16,7 @@ use SilverStripe\Versioned\Versioned;
  */
 class CWPSiteConfigExtension extends DataExtension
 {
-    use Configurable;
-
-    private static $hide_fields = [
-        'AddThisProfileID',
-        'LogoRetina',
-        'FooterLogoRetina'
-    ];
-
     private static $db = array(
-        'AddThisProfileID' => 'Varchar(32)',
         'FooterLogoLink' => 'Varchar(255)',
         'FooterLogoDescription' => 'Varchar(255)',
         'FooterLogoSecondaryLink' => 'Varchar(255)',
@@ -69,49 +57,8 @@ class CWPSiteConfigExtension extends DataExtension
     public function updateCMSFields(FieldList $fields)
     {
         $this
-            ->addSocialMedia($fields)
             ->addLogosAndIcons($fields)
-            ->addSearchOptions($fields)
-            ->removeFieldsForCurrentTheme($fields);
-    }
-
-    /**
-     * Remove fields from the given FieldList depending on the current theme and the configured fields to remove
-     *
-     * @param  FieldList $fields
-     * @return $this
-     */
-    protected function removeFieldsForCurrentTheme(FieldList $fields)
-    {
-        foreach ((array)$this->config()->hide_fields as $fieldNames) {
-            $fields->removeByName($fieldNames);
-        }
-        return $this;
-    }
-
-    /**
-     * Add or extend social media fields
-     *
-     * @param  FieldList $fields
-     * @return $this
-     */
-    protected function addSocialMedia(FieldList $fields)
-    {
-        $fields->addFieldToTab(
-            'Root.SocialMedia',
-            $addThisID = TextField::create(
-                'AddThisProfileID',
-                _t(__CLASS__ . '.AddThisField', 'AddThis Profile ID')
-            )
-        );
-        $addThisID->setRightTitle(
-            _t(
-                'CwpConfig.AddThisFieldDesc',
-                'Profile ID to be used all across the site (in the format <strong>ra-XXXXXXXXXXXXXXXX</strong>)'
-            )
-        );
-
-        return $this;
+            ->addSearchOptions($fields);
     }
 
     /**
@@ -313,6 +260,10 @@ class CWPSiteConfigExtension extends DataExtension
         return $this;
     }
 
+    /**
+     * Auto-publish any images attached to the SiteConfig object if it's not versioned. Versioned objects will
+     * handle their related objects via the "owns" API by default.
+     */
     public function onAfterWrite()
     {
         if (!$this->owner->hasExtension(Versioned::class)) {

--- a/tests/Extensions/CWPSiteConfigExtensionTest.php
+++ b/tests/Extensions/CWPSiteConfigExtensionTest.php
@@ -2,40 +2,13 @@
 
 namespace CWP\AgencyExtensions\Tests\Extensions;
 
-use SilverStripe\Forms\FileHandleField;
-
-
-
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\SiteConfig\SiteConfig;
-use SilverStripe\View\SSViewer;
 use SilverStripe\Forms\TextField;
-use CWP\AgencyExtensions\Extensions\CWPSiteConfigExtension;
+use SilverStripe\SiteConfig\SiteConfig;
 
 class CWPSiteConfigExtensionTest extends SapphireTest
 {
     protected $usesDatabase = true;
-
-    /**
-     * Ensure that other fields that are removed are only removed when the CWP theme is enabled
-     */
-    public function testRetinaFieldsAreRemovedByDefault()
-    {
-        $fields = SiteConfig::create()->getCMSFields();
-        $this->assertNull($fields->fieldByName('Root.LogosIcons.LogoRetina'));
-    }
-
-    /**
-     * Test that the existing fields are not removed when not using the CWP theme
-     */
-    public function testFieldsAreNotRemovedWhenConfiguredNotTo()
-    {
-        Config::modify()->set(CWPSiteConfigExtension::class, 'hide_fields', null);
-        $fields = SiteConfig::create()->getCMSFields();
-        $this->assertInstanceOf(FileHandleField::class, $fields->fieldByName('Root.LogosIcons.LogoRetina'));
-    }
 
     /**
      * Ensure that the two "search caption" fields exist and are in the right tab


### PR DESCRIPTION
These fields were in agency extensions for CWP 1.x to support users with the default theme. We don't support that theme in CWP 2.x any longer, so this PR removes them and the logic to "remove fields that aren't used in the current theme".