### PR TITLE
Update GridField UI row sorting component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "cwp/cwp": "^2",
-        "silverstripe/framework": "^4.1"
+        "silverstripe/framework": "^4.1",
+        "symbiote/silverstripe-gridfieldextensions": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Extensions/CarouselPageExtension.php
+++ b/src/Extensions/CarouselPageExtension.php
@@ -12,7 +12,7 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\ORM\DataList;
-use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use SilverStripe\Forms\GridField\GridFieldVersionedState;
 use SilverStripe\Forms\LiteralField;
 
@@ -59,9 +59,7 @@ class CarouselPageExtension extends DataExtension
         $gridConfig->removeComponentsByType(GridFieldDeleteAction::class);
         $gridConfig->addComponent(new GridFieldDeleteAction());
         $gridConfig->addComponent(new GridFieldVersionedState());
-        if (class_exists(GridFieldSortableRows::class)) {
-            $gridConfig->addComponent(new GridFieldSortableRows('SortOrder'));
-        }
+        $gridConfig->addComponent(new GridFieldOrderableRows('SortOrder'));
         $gridConfig->removeComponentsByType(GridFieldSortableHeader::class);
         $gridField->setModelClass(CarouselItem::class);
 


### PR DESCRIPTION
Change from `undefinedoffset/sortablegridfield` to
`symbiote/silverstripe-gridfieldextensions` so that in the future there
will be only one module solving this problem to maintain in the CWP
context.

c.f. https://github.com/silverstripe/cwp/issues/40