### PR TITLE
FIX Provide hidden input for FontPickerField value before its rendered

### DIFF
--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -404,8 +404,6 @@ class CWPSiteConfigExtension extends DataExtension
             return $this;
         }
 
-        $themeColors = $this->owner->config()->get('theme_colors');
-        $allThemeColors = $this->getThemeOptionsExcluding();
         $fonts = $this->owner->config()->get('theme_fonts');
 
         // Import each font via the google fonts api to render font preview
@@ -553,7 +551,7 @@ class CWPSiteConfigExtension extends DataExtension
     {
         $colorPickerEnabled = $this->owner->config()->get('enable_theme_color_picker');
 
-        if ($colorPickerEnabled && !isset($this->owner->record['HeaderBackground'])) {
+        if ($colorPickerEnabled && !$this->owner->HeaderBackground) {
             $this->owner->populateDefaults();
         }
     }

--- a/templates/CWP/AgencyExtensions/Forms/FontPickerField.ss
+++ b/templates/CWP/AgencyExtensions/Forms/FontPickerField.ss
@@ -1,3 +1,4 @@
 <div $AttributesHTML data-schema="$SchemaData.JSON">
     <%-- Field is rendered by React components --%>
+    <input type="hidden" $getAttributesHTML('class', 'type', 'id') value="$Value" />
 </div>


### PR DESCRIPTION
Also switch HeaderBackground check so it does not use a protected (unavailable) property
to access the data

Fixes https://github.com/silverstripe/cwp-agencyextensions/issues/15