### PR TITLE
FIX Ensure default values are set without using populateDefaults()

### DIFF
--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -62,16 +62,6 @@ class CWPSiteConfigExtension extends DataExtension
         'AppleTouchIcon57'
     ];
 
-    private static $defaults = [
-        'MainFontFamily' => 'nunito-sans',
-        'HeaderBackground' => 'default-background',
-        'NavigationBarBackground' => 'default-background',
-        'CarouselBackground' => 'default-background',
-        'FooterBackground' => 'default-background',
-        'AccentColor' => 'default-accent',
-        'TextLinkColor' => 'default-accent',
-    ];
-
     /**
      * Defines if the theme colour picker is enabled in the CMS
      *
@@ -543,16 +533,24 @@ class CWPSiteConfigExtension extends DataExtension
     }
 
     /**
-     * If HeaderBackground is not set, assume no theme colours exist and call populateDefaults if the color
-     * picker is enabled. This is done as SiteConfig won't call populateDefaults() on existing sites, so would
-     * not have any default theme_colors
+     * If HeaderBackground is not set, assume no theme colours exist and populate some defaults if the colour
+     * picker is enabled. We don't use populateDefaults() because we don't want SiteConfig to re-populate its own
+     * defaults.
      */
     public function onBeforeWrite()
     {
         $colorPickerEnabled = $this->owner->config()->get('enable_theme_color_picker');
 
         if ($colorPickerEnabled && !$this->owner->HeaderBackground) {
-            $this->owner->populateDefaults();
+            $this->owner->update([
+                'MainFontFamily' => FontPickerField::DEFAULT_VALUE,
+                'HeaderBackground' => 'default-background',
+                'NavigationBarBackground' => 'default-background',
+                'CarouselBackground' => 'default-background',
+                'FooterBackground' => 'default-background',
+                'AccentColor' => 'default-accent',
+                'TextLinkColor' => 'default-accent',
+            ]);
         }
     }
 }

--- a/src/Forms/FontPickerField.php
+++ b/src/Forms/FontPickerField.php
@@ -6,6 +6,13 @@ use SilverStripe\Forms\SingleSelectField;
 
 class FontPickerField extends SingleSelectField
 {
+    /**
+     * The default value if none is already configured
+     *
+     * @var string
+     */
+    const DEFAULT_VALUE = 'nunito-sans';
+
     public function __construct($name, $title = null, $source = array(), $value = null)
     {
         parent::__construct($name, $title, $source, $value);
@@ -30,5 +37,10 @@ class FontPickerField extends SingleSelectField
         $schemaData['value'] = $this->Value();
 
         return $schemaData;
+    }
+
+    public function Value()
+    {
+        return parent::Value() ?: self::DEFAULT_VALUE;
     }
 }

--- a/tests/Extensions/CWPSiteConfigExtensionTest.php
+++ b/tests/Extensions/CWPSiteConfigExtensionTest.php
@@ -65,4 +65,24 @@ class CWPSiteConfigExtensionTest extends SapphireTest
             ],
         ], $themeColors);
     }
+
+    public function testDefaultValuesAreNotWrittenWhenDisabled()
+    {
+        SiteConfig::config()->set('enable_theme_color_picker', false);
+
+        $siteConfig = SiteConfig::create();
+        $siteConfig->write();
+
+        $this->assertEmpty($siteConfig->HeaderBackground, 'Colour fields should not be written when disabled');
+    }
+
+    public function testDefaultValuesAreWrittenWhenEnabled()
+    {
+        SiteConfig::config()->set('enable_theme_color_picker', true);
+
+        $siteConfig = SiteConfig::create();
+        $siteConfig->write();
+
+        $this->assertNotEmpty($siteConfig->HeaderBackground, 'Colour fields should be written when enabled');
+    }
 }

--- a/tests/Forms/FontPickerFieldTest.php
+++ b/tests/Forms/FontPickerFieldTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CWP\AgencyExtensions\Tests\Forms;
+
+use CWP\AgencyExtensions\Forms\FontPickerField;
+use SilverStripe\Dev\SapphireTest;
+
+class FontPickerFieldTest extends SapphireTest
+{
+    public function testValueReturnsDefaultValueIfFalsy()
+    {
+        $field = new FontPickerField('test');
+        $this->assertSame(FontPickerField::DEFAULT_VALUE, $field->Value());
+    }
+}


### PR DESCRIPTION
Resolves #14

Also fixes default value rendering in FontPickerField when no value is set at all