### PR TITLE
Update CarouselItem's Parent relationship

### DIFF
--- a/src/Model/CarouselItem.php
+++ b/src/Model/CarouselItem.php
@@ -2,6 +2,7 @@
 
 namespace CWP\AgencyExtensions\Model;
 
+use CWP\CWP\PageTypes\BaseHomePage;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Core\Injector\Injector;
@@ -36,7 +37,7 @@ class CarouselItem extends DataObject
     ];
 
     private static $has_one = [
-        'Parent' => 'HomePage',
+        'Parent' => BaseHomePage::class,
         'Image' => Image::class,
         'PrimaryCallToAction' => SiteTree::class,
         'SecondaryCallToAction' => SiteTree::class


### PR DESCRIPTION
Issue #21 
Use CWP's BaseHomePage instead of 'HomePage' in the CarouselItem's Parent relationship.