### PR TITLE
Add legacy yaml file for SS3 to SS4 upgrades

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,0 +1,3 @@
+SilverStripe\ORM\DatabaseAdmin:
+  classname_value_remapping:
+    CarouselItem: CWP\AgencyExtensions\Model\CarouselItem


### PR DESCRIPTION
I've been working on a SS3 to SS4 upgrade and the CarouselItem included in the silverstripe/cwp-agencyextensions module doesn't get updated in the database, when doing a dev/build, to include the namespace. It would be useful if this legacy.yml file was included in the module, so that I don't have to add it manually to the project legacy file.