### PR TITLE
FIX Hero/Carousel items no longer have a duplicated versioning state badge on home pages

### DIFF
--- a/src/Extensions/CarouselPageExtension.php
+++ b/src/Extensions/CarouselPageExtension.php
@@ -58,7 +58,6 @@ class CarouselPageExtension extends DataExtension
         $gridConfig->removeComponentsByType(GridFieldAddExistingAutocompleter::class);
         $gridConfig->removeComponentsByType(GridFieldDeleteAction::class);
         $gridConfig->addComponent(new GridFieldDeleteAction());
-        $gridConfig->addComponent(new GridFieldVersionedState());
         $gridConfig->addComponent(new GridFieldOrderableRows('SortOrder'));
         $gridConfig->removeComponentsByType(GridFieldSortableHeader::class);
         $gridField->setModelClass(CarouselItem::class);


### PR DESCRIPTION
Fixes #25