### PR TITLE
Update for 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=2.x-dev
+    - COMPOSER_ROOT_VERSION=2.4.x-dev
 
 matrix:
   include:


### PR DESCRIPTION
composer.json does not need to be updated
```
    "require": {
        "cwp/cwp": "^2",
        "silverstripe/framework": "^4.1",
        "symbiote/silverstripe-gridfieldextensions": "^3.1"
    },
```