### PR TITLE
MNT Remove yarn test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "build": "yarn && yarn lint && NODE_ENV=production webpack -p --bail --progress",
     "watch": "yarn && NODE_ENV=development webpack --watch --progress",
     "css": "WEBPACK_CHILD=css npm run build",
-    "test": "jest",
     "lint": "eslint client/src && sass-lint --verbose client/src/**/*.scss",
     "lint-js": "eslint client/src",
     "lint-js-fix": "eslint client/src --fix",


### PR DESCRIPTION
Fixes broken yarn test 

https://github.com/silverstripe/cwp-agencyextensions/runs/7380644680?check_suite_focus=true#step:12:228

Which is failing because it's trying to run `cwp-agencyextensions/vendor/silverstripe/admin/thirdparty/jquery-changetracker/spec/unit/spec.js`

While that's obviously incorrect, there's actually no reason to run `yarn test` at all as this module has no js tests in it

There's a condition in gha-run-tests that mean yarn test does not run if there is no 'test' script in package.json

https://github.com/silverstripe/gha-run-tests/blob/1/action.yml#L200

```
        if [[ $(cat package.json | jq -r '.scripts.test') != 'null' ]]; then
          echo "Running yarn test"
          yarn run test
        fi
```



