### PR TITLE
MNT Ignore lint failure we can't fix

### DIFF
--- a/src/Extensions/CWPSiteConfigExtension.php
+++ b/src/Extensions/CWPSiteConfigExtension.php
@@ -373,6 +373,7 @@ class CWPSiteConfigExtension extends DataExtension
             'Root.SearchOptions',
             TextField::create(
                 'EmptySearch',
+                /** @phpstan-ignore translation.key (legacy string for EOL module) */
                 _t(
                     'CWP.SITECONFIG.EmptySearch',
                     'Text to display when there is no search query'
@@ -383,6 +384,7 @@ class CWPSiteConfigExtension extends DataExtension
             'Root.SearchOptions',
             TextField::create(
                 'NoSearchResults',
+                /** @phpstan-ignore translation.key (legacy string for EOL module) */
                 _t(
                     'CWP.SITECONFIG.NoResult',
                     'Text to display when there are no results'


### PR DESCRIPTION
Fixes https://github.com/silverstripe/cwp-agencyextensions/actions/runs/10269334178/job/28414559994
> First argument passed to _t() must have exactly one period.

We should avoid changing i18n keys outside of a major release, and this module is on the chopping block to lose its supported status in CMS 6 so no sense changing it there either.

## Issue
- https://github.com/silverstripe/.github/issues/290